### PR TITLE
fix: updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "body-parser": "1.6.7",
+    "body-parser": "^1.20.2",
     "cookie-session": "1.0.2",
-    "errorhandler": "1.2.0",
-    "express": "4.8.7",
-    "jade": "1.7.0",
-    "ovsdb-client": "1.0.1",
+    "errorhandler": "^1.5.1",
+    "express": "^4.19.2",
+    "jade": "^0.29.0",
+    "ovsdb-client": "^1.0.1",
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "debug": "1.0.4"
+    "debug": "^4.3.4"
   },
   "license": "AGPL-3.0",
   "name": "Open_vMonitor",


### PR DESCRIPTION
Updated npm dependences to remove CVEs when possible. After updating the ovsdb-client should disappear.

```
# npm audit report

node-uuid  <1.4.4
Severity: high
Insecure Entropy Source - Math.random() in node-uuid - https://github.com/advisories/GHSA-265q-28rp-chq5
No fix available
node_modules/node-uuid
  ovsdb-client  *
  Depends on vulnerable versions of node-uuid
  node_modules/ovsdb-client

2 high severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.
```